### PR TITLE
Improve questline structure and accessibility

### DIFF
--- a/config/ftbquests/quests/chapters/1_basic_processing.snbt
+++ b/config/ftbquests/quests/chapters/1_basic_processing.snbt
@@ -158,22 +158,91 @@
 			]
 		}
 		{
-			title: "Process Your First Ores"
-			icon: "create:crushed_raw_iron"
+			title: "Set Up Item Conveying"
+			icon: "create:belt_connector"
 			x: -3.0d
 			y: 5.5d
 			description: [
-				"Use the Mechanical Press to process raw ores!"
+				"Create's belt system is the backbone of automation!"
 				""
-				"Crushing raw ores gives you crushed ores, which can be smelted for extra output."
+				"Craft belts, depots, and funnels to move items around your factory."
 				""
-				"This is your first step into efficient ore processing."
+				"Belts are simple to craft and don't require any advanced materials."
 			]
 			dependencies: ["1000000000000011"]
 			id: "1000000000000016"
 			tasks: [
 				{
 					id: "1000000000000017"
+					type: "item"
+					title: "Belt Connectors"
+					item: "create:belt_connector"
+					count: 8
+				}
+				{
+					id: "1000000000000060"
+					type: "item"
+					title: "Depot or Funnel"
+					item: {
+						id: "itemfilters:or"
+						Count: 1b
+						tag: {
+							items: [
+								{
+									id: "create:depot"
+									Count: 1b
+								}
+								{
+									id: "create:andesite_funnel"
+									Count: 1b
+								}
+								{
+									id: "create:chute"
+									Count: 1b
+								}
+							]
+						}
+					}
+					count: 4
+				}
+			]
+			rewards: [
+				{
+					id: "1000000000000018"
+					type: "item"
+					item: "create:belt_connector"
+					count: 16
+				}
+				{
+					id: "1000000000000019"
+					type: "item"
+					item: "create:andesite_funnel"
+					count: 8
+				}
+			]
+		}
+		{
+			title: "Crush Some Ores"
+			icon: "create:millstone"
+			x: -3.0d
+			y: 7.0d
+			description: [
+				"Use a Millstone to process ores more efficiently!"
+				""
+				"The Millstone crushes raw ores into crushed ores, which smelt into more ingots."
+				""
+				"This is your first step into efficient ore processing - no advanced materials needed!"
+			]
+			dependencies: ["1000000000000016"]
+			id: "1000000000000020"
+			tasks: [
+				{
+					id: "1000000000000021"
+					type: "item"
+					item: "create:millstone"
+				}
+				{
+					id: "1000000000000022"
 					type: "item"
 					title: "Any Crushed Ore"
 					item: {
@@ -205,79 +274,16 @@
 			]
 			rewards: [
 				{
-					id: "1000000000000018"
+					id: "1000000000000023"
 					type: "item"
 					item: "minecraft:raw_iron"
 					count: 32
 				}
 				{
-					id: "1000000000000019"
+					id: "1000000000000024"
 					type: "item"
 					item: "minecraft:raw_copper"
 					count: 32
-				}
-			]
-		}
-		{
-			title: "Automate Basic Crafting"
-			icon: "create:mechanical_crafter"
-			x: -3.0d
-			y: 7.0d
-			description: [
-				"Mechanical Crafters let you automate crafting recipes!"
-				""
-				"Arrange them in the shape of the recipe you want to automate."
-				""
-				"This is the foundation of Create automation."
-			]
-			dependencies: ["1000000000000016"]
-			id: "1000000000000020"
-			tasks: [
-				{
-					id: "1000000000000021"
-					type: "item"
-					item: "create:mechanical_crafter"
-					count: 3
-				}
-				{
-					id: "1000000000000022"
-					type: "item"
-					title: "Automated Item"
-					item: {
-						id: "itemfilters:or"
-						Count: 1b
-						tag: {
-							items: [
-								{
-									id: "create:andesite_casing"
-									Count: 1b
-								}
-								{
-									id: "create:copper_casing"
-									Count: 1b
-								}
-								{
-									id: "create:brass_casing"
-									Count: 1b
-								}
-							]
-						}
-					}
-					count: 8
-				}
-			]
-			rewards: [
-				{
-					id: "1000000000000023"
-					type: "item"
-					item: "create:brass_ingot"
-					count: 16
-				}
-				{
-					id: "1000000000000024"
-					type: "item"
-					item: "create:electron_tube"
-					count: 4
 				}
 			]
 		}
@@ -451,6 +457,240 @@
 					type: "item"
 					item: "immersiveengineering:connector_mv"
 					count: 4
+				}
+			]
+		}
+		{
+			title: "Storage Drawers"
+			icon: "storagedrawers:oak_full_drawers_4"
+			x: -6.0d
+			y: 2.0d
+			shape: "circle"
+			description: [
+				"Storage Drawers provide efficient, visual item storage!"
+				""
+				"Drawers show what's inside and can hold huge amounts of a single item type."
+				""
+				"Available from the start - no progression required!"
+			]
+			dependencies: ["1000000000000002"]
+			id: "1000000000000046"
+			tasks: [
+				{
+					id: "1000000000000047"
+					type: "item"
+					title: "Any Drawer"
+					item: {
+						id: "itemfilters:or"
+						Count: 1b
+						tag: {
+							items: [
+								{
+									id: "storagedrawers:oak_full_drawers_1"
+									Count: 1b
+								}
+								{
+									id: "storagedrawers:oak_full_drawers_2"
+									Count: 1b
+								}
+								{
+									id: "storagedrawers:oak_full_drawers_4"
+									Count: 1b
+								}
+							]
+						}
+					}
+					count: 4
+				}
+			]
+			rewards: [
+				{
+					id: "1000000000000048"
+					type: "item"
+					item: "storagedrawers:upgrade_template"
+					count: 4
+				}
+				{
+					id: "1000000000000049"
+					type: "item"
+					item: "storagedrawers:drawer_key"
+				}
+			]
+		}
+		{
+			title: "Tinker's Construct"
+			icon: "tconstruct:seared_melter"
+			x: -6.0d
+			y: 4.0d
+			shape: "circle"
+			description: [
+				"Tinker's Construct lets you create customizable, upgradeable tools!"
+				""
+				"Start with a Seared Melter to melt metals, then cast tool parts."
+				""
+				"Available from the start - no progression required!"
+			]
+			dependencies: ["1000000000000002"]
+			id: "1000000000000050"
+			tasks: [
+				{
+					id: "1000000000000051"
+					type: "item"
+					item: "tconstruct:seared_melter"
+				}
+				{
+					id: "1000000000000052"
+					type: "item"
+					title: "Any Cast"
+					item: {
+						id: "itemfilters:or"
+						Count: 1b
+						tag: {
+							items: [
+								{
+									id: "tconstruct:pickaxe_head_cast"
+									Count: 1b
+								}
+								{
+									id: "tconstruct:sword_blade_cast"
+									Count: 1b
+								}
+								{
+									id: "tconstruct:tool_handle_cast"
+									Count: 1b
+								}
+							]
+						}
+					}
+				}
+			]
+			rewards: [
+				{
+					id: "1000000000000053"
+					type: "item"
+					item: "tconstruct:seared_brick"
+					count: 32
+				}
+				{
+					id: "1000000000000054"
+					type: "item"
+					item: "tconstruct:grout"
+					count: 16
+				}
+			]
+		}
+		{
+			title: "ComputerCraft"
+			icon: "computercraft:computer_normal"
+			x: 6.0d
+			y: 2.0d
+			shape: "circle"
+			description: [
+				"ComputerCraft adds programmable computers and turtles!"
+				""
+				"Write Lua programs to automate tasks and control your base."
+				""
+				"Available from the start - no progression required!"
+			]
+			dependencies: ["1000000000000002"]
+			id: "1000000000000055"
+			tasks: [
+				{
+					id: "1000000000000056"
+					type: "item"
+					title: "Any Computer"
+					item: {
+						id: "itemfilters:or"
+						Count: 1b
+						tag: {
+							items: [
+								{
+									id: "computercraft:computer_normal"
+									Count: 1b
+								}
+								{
+									id: "computercraft:computer_advanced"
+									Count: 1b
+								}
+							]
+						}
+					}
+				}
+			]
+			rewards: [
+				{
+					id: "1000000000000057"
+					type: "item"
+					item: "computercraft:disk"
+					count: 4
+				}
+				{
+					id: "1000000000000058"
+					type: "item"
+					item: "computercraft:cable"
+					count: 16
+				}
+			]
+		}
+		{
+			title: "Sophisticated Backpacks"
+			icon: "sophisticatedbackpacks:backpack"
+			x: 6.0d
+			y: 4.0d
+			shape: "circle"
+			description: [
+				"Sophisticated Backpacks adds upgradeable portable storage!"
+				""
+				"Craft a backpack and add upgrades for filtering, auto-pickup, and more."
+				""
+				"Available from the start - no progression required!"
+			]
+			dependencies: ["1000000000000002"]
+			id: "1000000000000061"
+			tasks: [
+				{
+					id: "1000000000000062"
+					type: "item"
+					item: "sophisticatedbackpacks:backpack"
+				}
+				{
+					id: "1000000000000063"
+					type: "item"
+					title: "Any Upgrade"
+					item: {
+						id: "itemfilters:or"
+						Count: 1b
+						tag: {
+							items: [
+								{
+									id: "sophisticatedbackpacks:pickup_upgrade"
+									Count: 1b
+								}
+								{
+									id: "sophisticatedbackpacks:filter_upgrade"
+									Count: 1b
+								}
+								{
+									id: "sophisticatedbackpacks:stack_upgrade_tier_1"
+									Count: 1b
+								}
+							]
+						}
+					}
+				}
+			]
+			rewards: [
+				{
+					id: "1000000000000064"
+					type: "item"
+					item: "sophisticatedbackpacks:upgrade_base"
+					count: 4
+				}
+				{
+					id: "1000000000000065"
+					type: "item"
+					item: "leather"
+					count: 8
 				}
 			]
 		}

--- a/config/ftbquests/quests/chapters/2_steel_electricity.snbt
+++ b/config/ftbquests/quests/chapters/2_steel_electricity.snbt
@@ -350,16 +350,17 @@
 			]
 		}
 		{
-			title: "Unlock: Storage Drawers"
-			icon: "storagedrawers:oak_full_drawers_4"
+			title: "Storage Drawers: Controller Network"
+			icon: "storagedrawers:controller"
 			x: 0.0d
 			y: 6.5d
+			shape: "circle"
 			description: [
-				"Storage Drawers provide efficient item storage with visual access!"
+				"Expand your drawer system with a Controller!"
 				""
-				"Build drawer controllers for easy mass storage management."
+				"A Drawer Controller connects to adjacent drawers and allows you to insert/extract from all at once."
 				""
-				"Perfect for organizing your growing resource stockpile."
+				"Add storage upgrades to increase drawer capacity!"
 			]
 			dependencies: [
 				"2000000000000025"
@@ -371,40 +372,61 @@
 				{
 					id: "2000000000000041"
 					type: "item"
-					item: "storagedrawers:oak_full_drawers_4"
-					count: 4
+					item: "storagedrawers:controller"
 				}
 				{
 					id: "2000000000000042"
 					type: "item"
-					item: "storagedrawers:controller"
+					title: "Storage Upgrade"
+					item: {
+						id: "itemfilters:or"
+						Count: 1b
+						tag: {
+							items: [
+								{
+									id: "storagedrawers:obsidian_storage_upgrade"
+									Count: 1b
+								}
+								{
+									id: "storagedrawers:iron_storage_upgrade"
+									Count: 1b
+								}
+								{
+									id: "storagedrawers:gold_storage_upgrade"
+									Count: 1b
+								}
+							]
+						}
+					}
+					count: 4
 				}
 			]
 			rewards: [
 				{
 					id: "2000000000000043"
 					type: "item"
-					item: "storagedrawers:upgrade_template"
+					item: "storagedrawers:diamond_storage_upgrade"
 					count: 4
 				}
 				{
 					id: "2000000000000044"
 					type: "item"
-					item: "storagedrawers:drawer_key"
+					item: "storagedrawers:compacting_drawers_3"
 				}
 			]
 		}
 		{
-			title: "Unlock: Tinker's Construct"
+			title: "Tinker's Construct: Full Smeltery"
 			icon: "tconstruct:smeltery_controller"
 			x: 5.0d
 			y: 6.5d
+			shape: "circle"
 			description: [
-				"Tinker's Construct allows you to create customizable tools!"
+				"Build a complete Smeltery for large-scale metal processing!"
 				""
-				"Build a Smeltery to melt down metals and cast tools."
+				"The Smeltery can melt multiple metals at once and alloy them together."
 				""
-				"Craft powerful, upgradeable equipment for your adventures."
+				"Craft a complete tool using the smeltery's casting system!"
 			]
 			dependencies: [
 				"2000000000000025"
@@ -421,21 +443,41 @@
 				{
 					id: "2000000000000047"
 					type: "item"
-					item: "tconstruct:seared_melter"
+					title: "Any Tinker's Tool"
+					item: {
+						id: "itemfilters:or"
+						Count: 1b
+						tag: {
+							items: [
+								{
+									id: "tconstruct:pickaxe"
+									Count: 1b
+								}
+								{
+									id: "tconstruct:mattock"
+									Count: 1b
+								}
+								{
+									id: "tconstruct:sledge_hammer"
+									Count: 1b
+								}
+							]
+						}
+					}
 				}
 			]
 			rewards: [
 				{
 					id: "2000000000000048"
 					type: "item"
-					item: "tconstruct:seared_brick"
-					count: 32
+					item: "tconstruct:cobalt_ingot"
+					count: 8
 				}
 				{
 					id: "2000000000000049"
 					type: "item"
-					item: "tconstruct:grout"
-					count: 16
+					item: "tconstruct:seared_drain"
+					count: 2
 				}
 			]
 		}

--- a/config/ftbquests/quests/chapters/3_oil_plastic.snbt
+++ b/config/ftbquests/quests/chapters/3_oil_plastic.snbt
@@ -230,11 +230,15 @@
 			x: 0.0d
 			y: 5.0d
 			description: [
-				"Convert oil products into plastic using PneumaticCraft!"
+				"Plastic is essential for advanced circuits and components!"
 				""
-				"Build a Thermopneumatic Processing Plant."
+				"You have multiple options for producing plastic:"
 				""
-				"Plastic is essential for advanced circuits and components."
+				"&6TFMG:&r Use the built-in plastic production line"
+				"&cImmersive Engineering:&r Build the Plastic Solidifier multiblock"
+				"&bPneumaticCraft:&r Thermopneumatic Processing Plant"
+				""
+				"Choose any method that fits your setup!"
 			]
 			dependencies: [
 				"3000000000000015"
@@ -246,12 +250,27 @@
 				{
 					id: "3000000000000026"
 					type: "item"
-					item: "pneumaticcraft:thermopneumatic_processing_plant"
-				}
-				{
-					id: "3000000000000027"
-					type: "item"
-					item: "pneumaticcraft:plastic"
+					title: "Any Plastic"
+					item: {
+						id: "itemfilters:or"
+						Count: 1b
+						tag: {
+							items: [
+								{
+									id: "pneumaticcraft:plastic"
+									Count: 1b
+								}
+								{
+									id: "tfmg:plastic_sheet"
+									Count: 1b
+								}
+								{
+									id: "industrialforegoing:plastic"
+									Count: 1b
+								}
+							]
+						}
+					}
 					count: 64
 				}
 			]

--- a/config/ftbquests/quests/chapters/4_chemistry.snbt
+++ b/config/ftbquests/quests/chapters/4_chemistry.snbt
@@ -4,13 +4,13 @@
 	order_index: 4
 	filename: "4_chemistry"
 	title: "Tier 4: Chemistry"
-	icon: "mekanism:chemical_tank"
+	icon: "mekanism:basic_chemical_tank"
 	default_quest_shape: ""
 	default_hide_dependency_lines: false
 	quests: [
 		{
 			title: "Welcome to Tier 4"
-			icon: "mekanism:chemical_tank"
+			icon: "mekanism:basic_chemical_tank"
 			x: 0.0d
 			y: 0.0d
 			shape: "hexagon"

--- a/config/ftbquests/quests/chapters/5_electronics.snbt
+++ b/config/ftbquests/quests/chapters/5_electronics.snbt
@@ -268,16 +268,17 @@
 			]
 		}
 		{
-			title: "ComputerCraft Basics"
-			icon: "computercraft:computer_advanced"
+			title: "ComputerCraft: Networking"
+			icon: "computercraft:wired_modem_full"
 			x: 0.0d
 			y: 5.0d
+			shape: "circle"
 			description: [
-				"ComputerCraft adds programmable computers and turtles!"
+				"Connect your computers into a network!"
 				""
-				"Write Lua programs to automate complex tasks."
+				"Wired modems allow computers to communicate and share peripherals."
 				""
-				"Computers can control and monitor your entire factory."
+				"Use networking to build a factory control system!"
 			]
 			dependencies: [
 				"5000000000000012"
@@ -289,17 +290,19 @@
 				{
 					id: "5000000000000030"
 					type: "item"
-					item: "computercraft:computer_advanced"
+					item: "computercraft:wired_modem_full"
+					count: 4
 				}
 				{
 					id: "5000000000000031"
 					type: "item"
-					item: "computercraft:disk_drive"
+					item: "computercraft:cable"
+					count: 32
 				}
 				{
 					id: "5000000000000032"
 					type: "item"
-					item: "computercraft:wired_modem"
+					item: "computercraft:monitor_advanced"
 					count: 4
 				}
 			]
@@ -307,13 +310,13 @@
 				{
 					id: "5000000000000033"
 					type: "item"
-					item: "computercraft:disk"
-					count: 8
+					item: "computercraft:wireless_modem_advanced"
+					count: 4
 				}
 				{
 					id: "5000000000000034"
 					type: "item"
-					item: "computercraft:wireless_modem_advanced"
+					item: "computercraft:speaker"
 					count: 2
 				}
 			]

--- a/config/ftbquests/quests/chapters/side_railways.snbt
+++ b/config/ftbquests/quests/chapters/side_railways.snbt
@@ -4,7 +4,7 @@
 	order_index: 0
 	filename: "side_railways"
 	title: "Side: Railways \& Trains"
-	icon: "railways:track"
+	icon: "create:track"
 	default_quest_shape: ""
 	default_hide_dependency_lines: false
 	quests: [


### PR DESCRIPTION
## Summary
- Replace Tier 1 Create quests with easier alternatives that don't require brass (belts/funnels/millstone instead of mechanical crafters)
- Move Storage Drawers, Tinker's Construct, ComputerCraft, and Sophisticated Backpacks to Tier 1 for immediate access
- Update Plastic quest description to mention all three production methods (TFMG, IE multiblock, PneumaticCraft)
- Fix invalid/inaccurate quest icons

## Changes

### Tier 1 Quest Replacements
| Old Quest | New Quest | Reason |
|-----------|-----------|--------|
| Process Your First Ores | Set Up Item Conveying | Brass requirement removed |
| Automate Basic Crafting | Crush Some Ores | Mechanical crafters need brass |

### Mods Moved to Tier 1
- **Storage Drawers**: Basic drawer crafting (advanced controller quest remains in Tier 2)
- **Tinker's Construct**: Seared Melter + casts (full Smeltery quest remains in Tier 2)
- **ComputerCraft**: Basic computer (networking quest remains in Tier 5)
- **Sophisticated Backpacks**: New quest for basic backpack + upgrade

### Plastic Quest Update
Description now explains all three production methods:
- TFMG built-in plastic production line
- Immersive Engineering Plastic Solidifier multiblock
- PneumaticCraft Thermopneumatic Processing Plant

### Icon Fixes
- Fixed railways chapter icon (`railways:track` -> `create:track`)
- Fixed chemistry icons (`mekanism:chemical_tank` -> `mekanism:basic_chemical_tank`)

## Test plan
- [ ] Verify new Tier 1 quests are completable without brass
- [ ] Verify Storage Drawers, Tinker's, ComputerCraft, Backpacks quests appear in Tier 1
- [ ] Verify Plastic quest accepts all three plastic types
- [ ] Verify all quest icons display correctly in-game

🤖 Generated with [Claude Code](https://claude.com/claude-code)