### PR TITLE
Fix KubeJS recipe errors and add IE support

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -1786,11 +1786,11 @@ hash = "d49919ec28a4d4bdd0a9702079a45a8c646db14eabc89d2bdf731c31d63f7da7"
 
 [[files]]
 file = "kubejs/server_scripts/recipes/mbd2_machines.js"
-hash = "96350d4777aabc18ee5e4694cdb34366e3ba8f5b9987192e02d926f9c23b4dac"
+hash = "c3c5c22ffc2efcc084b1153a15ea431c7f697b08a39676f9e034be02c61f7fb5"
 
 [[files]]
 file = "kubejs/server_scripts/recipes/military_defense.js"
-hash = "140bf6044595d095f33af074d91d58b58e23cd0a9e65b47e1ea593783eb09f81"
+hash = "17baead5d448df369995e94eb5023763cebbc289432096a429c83f95b46c8c9e"
 
 [[files]]
 file = "kubejs/server_scripts/recipes/tier2_steel.js"
@@ -1802,7 +1802,7 @@ hash = "8fdb68913474d0441a9f1359b5043ee1221fa5720c1a5f498daceb18f4337f4c"
 
 [[files]]
 file = "kubejs/server_scripts/recipes/tier3_plastic_multiblock.js"
-hash = "4ee1211a80cedadad61b319b65fbcb3beca8a5ba5e272d03b65fa1c1fa3323f1"
+hash = "6c9c40ecd95a7ecbb3c6a11c1ed1760e6dc5ca25b05fc24fbfad4a55ad83a1cd"
 
 [[files]]
 file = "kubejs/server_scripts/recipes/tier4_chemistry.js"
@@ -2785,6 +2785,11 @@ metafile = true
 [[files]]
 file = "mods/kubejs-create.pw.toml"
 hash = "e9ea701c9fc9bb54d1bd3b6998403a229f896449c0d15b5df23dc46e20ac5092"
+metafile = true
+
+[[files]]
+file = "mods/kubejs-immersive-engineering-unofficial.pw.toml"
+hash = "7ae9c42d464cec49e3f4f9da4cea255dcc352e263acd5068f9ece78f55203e6a"
 metafile = true
 
 [[files]]

--- a/kubejs/server_scripts/recipes/mbd2_machines.js
+++ b/kubejs/server_scripts/recipes/mbd2_machines.js
@@ -1,172 +1,47 @@
 // kubejs/server_scripts/recipes/mbd2_machines.js
 // MBD2 Machine Recipes - Chemical Mixer and Advanced Circuit Fabricator
-// These recipes work with Multiblocked2 multiblock structures
+//
+// NOTE: MBD2 recipes are defined within the multiblock definition files (.mb),
+// not via KubeJS. The recipe type 'mbd2:mbd_recipe' does not exist.
+// These recipes are commented out - MBD2 machines use their internal recipe system.
+// To add/modify MBD2 recipes, use the MBD2 in-game recipe editor.
 
 ServerEvents.recipes(event => {
-    console.log('Adding MBD2 machine recipes...');
+    console.log('MBD2 machine recipes - using internal MBD2 recipe system');
 
     // ============================================================
-    // CHEMICAL MIXER / CHEMICAL PLANT RECIPES
-    // Multiblock: mbd2:chemical_plant
-    // Purpose: Create plastic from Immersive Petroleum inputs
+    // MBD2 RECIPE DOCUMENTATION
+    // ============================================================
+    // MBD2 multiblocks have their recipes defined in the .mb files
+    // located in ldlib/assets/mbd2/multiblock/
+    //
+    // To add recipes to MBD2 machines:
+    // 1. Use the MBD2 in-game recipe editor (right-click controller)
+    // 2. Or modify the .mb files directly using MBD2's tools
+    //
+    // The following recipe types are available in the reference pack:
+    // - mixing.rt - For mixing operations
+    // - chemical_processing.rt - For chemical plant
+    // - advanced_assemblying.rt - For computer controlled assembler
     // ============================================================
 
-    // Chemical Mixer Recipe - Ethylene + Coal Coke → Unprocessed Plastic
-    // Used in the Chemical Plant multiblock
-    event.custom({
-        type: 'mbd2:mbd_recipe',
-        machine: 'mbd2:chemical_plant',
-        duration: 100, // 5 seconds
-        inputs: {
-            item_in: [
-                { ingredient: { tag: 'forge:coal_coke' }, count: 1 }
-            ],
-            fluid_in: [
-                { content: { fluid: 'tfmg:ethylene', amount: 100 } }
-            ]
-        },
-        outputs: {
-            item_out: [
-                { content: { item: 'kubejs:unprocessed_plastic', count: 1 } }
-            ]
-        },
-        conditions: [
-            { type: 'mbd2:machine_level', min: 1 }
-        ],
-        data: {
-            energy: 12800  // FE cost
-        }
-    });
+    // Chemical Plant recipes are defined in:
+    // ldlib/assets/mbd2/multiblock/chemical_plant.mb
+    //
+    // Expected recipe:
+    // - Input: 100mb Ethylene + 1x Coal Coke
+    // - Output: 1x Unprocessed Plastic
+    // - Energy: 12800 FE
 
-    // Alternative: Direct plastic production from oil (higher cost)
-    event.custom({
-        type: 'mbd2:mbd_recipe',
-        machine: 'mbd2:chemical_plant',
-        duration: 200, // 10 seconds
-        inputs: {
-            fluid_in: [
-                { content: { fluid: 'immersivepetroleum:oil', amount: 500 } },
-                { content: { fluid: 'minecraft:lava', amount: 100 } }
-            ]
-        },
-        outputs: {
-            item_out: [
-                { content: { item: 'kubejs:unprocessed_plastic', count: 2 } }
-            ]
-        },
-        data: {
-            energy: 25600
-        }
-    });
+    // Computer Controlled Assembler recipes are defined in:
+    // ldlib/assets/mbd2/multiblock/computer_controlled_assembler.mb
+    //
+    // Expected recipes for Advanced Circuits:
+    // - 4 PCBs + 8 Infused Alloy + 4 Reinforced Alloy + 2 Redstone Blocks → 2 Advanced Circuits
+    // - 6 PCBs + 4 Infused Alloy + 2 Reinforced Alloy + 4 Redstone → 2 Advanced Circuits
+    // - 2 PCBs + 4 Infused Alloy + 8 Steel Sheets + 1 Diamond → 1 Advanced Circuit
 
-    // ============================================================
-    // ADVANCED CIRCUIT FABRICATOR RECIPES
-    // Multiblock: mbd2:computer_controlled_assembler
-    // Purpose: Create advanced circuits from PCBs and alloys
-    // ============================================================
-
-    // Primary Recipe - Standard advanced circuit production
-    // 4 PCBs + 8 Infused Alloy + 4 Reinforced Alloy + 2 Redstone Blocks → 2 Advanced Circuits
-    event.custom({
-        type: 'mbd2:mbd_recipe',
-        machine: 'mbd2:computer_controlled_assembler',
-        duration: 400, // 20 seconds
-        inputs: {
-            item_in: [
-                { ingredient: { item: 'pneumaticcraft:printed_circuit_board' }, count: 4 },
-                { ingredient: { item: 'mekanism:alloy_infused' }, count: 8 },
-                { ingredient: { item: 'mekanism:alloy_reinforced' }, count: 4 },
-                { ingredient: { item: 'minecraft:redstone_block' }, count: 2 }
-            ]
-        },
-        outputs: {
-            item_out: [
-                { content: { item: 'mineman:advanced_circuit', count: 2 } }
-            ]
-        },
-        data: {
-            energy: 50000
-        }
-    });
-
-    // Alternative Recipe - More PCBs, fewer alloys
-    // 6 PCBs + 4 Infused Alloy + 2 Reinforced Alloy + 4 Redstone → 2 Advanced Circuits
-    event.custom({
-        type: 'mbd2:mbd_recipe',
-        machine: 'mbd2:computer_controlled_assembler',
-        duration: 300, // 15 seconds
-        inputs: {
-            item_in: [
-                { ingredient: { item: 'pneumaticcraft:printed_circuit_board' }, count: 6 },
-                { ingredient: { item: 'mekanism:alloy_infused' }, count: 4 },
-                { ingredient: { item: 'mekanism:alloy_reinforced' }, count: 2 },
-                { ingredient: { item: 'minecraft:redstone' }, count: 4 }
-            ]
-        },
-        outputs: {
-            item_out: [
-                { content: { item: 'mineman:advanced_circuit', count: 2 } }
-            ]
-        },
-        data: {
-            energy: 40000
-        }
-    });
-
-    // Early Game Recipe - Lower cost, lower yield
-    // 2 PCBs + 4 Infused Alloy + 8 Steel Sheets + 1 Diamond → 1 Advanced Circuit
-    event.custom({
-        type: 'mbd2:mbd_recipe',
-        machine: 'mbd2:computer_controlled_assembler',
-        duration: 200, // 10 seconds
-        inputs: {
-            item_in: [
-                { ingredient: { item: 'pneumaticcraft:printed_circuit_board' }, count: 2 },
-                { ingredient: { item: 'mekanism:alloy_infused' }, count: 4 },
-                { ingredient: { item: 'tfmg:steel_sheet' }, count: 8 },
-                { ingredient: { item: 'minecraft:diamond' }, count: 1 }
-            ]
-        },
-        outputs: {
-            item_out: [
-                { content: { item: 'mineman:advanced_circuit', count: 1 } }
-            ]
-        },
-        data: {
-            energy: 30000
-        }
-    });
-
-    // ============================================================
-    // BASIC MIXER RECIPES (Alternative Chemical Processing)
-    // Multiblock: mbd2:basic_mixer
-    // Purpose: Simpler mixing operations
-    // ============================================================
-
-    // Basic plastic mixture creation
-    event.custom({
-        type: 'mbd2:mbd_recipe',
-        machine: 'mbd2:basic_mixer',
-        duration: 80,
-        inputs: {
-            fluid_in: [
-                { content: { fluid: 'tfmg:ethylene', amount: 200 } }
-            ],
-            item_in: [
-                { ingredient: { tag: 'forge:dusts/coal' }, count: 2 }
-            ]
-        },
-        outputs: {
-            item_out: [
-                { content: { item: 'kubejs:unprocessed_plastic', count: 1 } }
-            ]
-        },
-        data: {
-            energy: 8000
-        }
-    });
-
-    console.log('MBD2 machine recipes added successfully!');
+    console.log('MBD2 recipes are handled by internal MBD2 recipe system');
 });
 
 // ============================================================

--- a/kubejs/server_scripts/recipes/military_defense.js
+++ b/kubejs/server_scripts/recipes/military_defense.js
@@ -1,172 +1,169 @@
 // kubejs/server_scripts/recipes/military_defense.js
 // Recipe modifications for Ballistix, Nuclear Science, Blastcraft, and Modular Forcefields
+//
+// NOTE: These recipes are commented out because the item IDs need verification.
+// The Electrodynamics ecosystem mods use specific naming conventions.
+// To find correct item IDs:
+// 1. Press F3+H in-game to enable advanced tooltips
+// 2. Hover over items in JEI to see their registry names
+// 3. Update the item IDs below accordingly
+//
+// Common naming patterns for aurilisdev mods:
+// - ballistix:launcherplatform (not missilelauncher)
+// - ballistix:missileconventional
+// - nuclearscience:centrifuge
+// - blastcraft:reinforcedconcrete
+// - modularforcefields:forcefieldemitter
 
 ServerEvents.recipes(event => {
-    console.log('Applying Military & Defense recipe changes...');
+    console.log('Military & Defense recipes - item IDs need verification');
 
-    // === ELECTRODYNAMICS INTEGRATION ===
-    // Electrodynamics serves as the base for all military mods
-    // Gate some advanced items behind steel tier (Tier 2)
-    
+    // ============================================================
+    // RECIPE DOCUMENTATION
+    // ============================================================
+    // These recipes require verification of item IDs in-game.
+    // The mods are installed but item registry names may differ.
+    // ============================================================
+
     // === BLASTCRAFT GATING ===
     // Reinforced blocks require steel production (Tier 2)
-    
-    // Remove original reinforced concrete recipe if it exists
-    event.remove({ output: 'blastcraft:reinforcedconcrete' });
-    
-    // Reinforced Concrete - requires steel
-    event.shaped('8x blastcraft:reinforcedconcrete', [
-        'CSC',
-        'SIS',
-        'CSC'
-    ], {
-        C: 'minecraft:stone',
-        S: '#forge:plates/steel',
-        I: 'minecraft:iron_ingot'
-    });
+
+    // TODO: Verify item ID - might be blastcraft:reinforced_concrete or blastcraft:reinforcedconcrete
+    // event.remove({ output: 'blastcraft:reinforcedconcrete' });
+    // event.shaped('8x blastcraft:reinforcedconcrete', [
+    //     'CSC',
+    //     'SIS',
+    //     'CSC'
+    // ], {
+    //     C: 'minecraft:stone',
+    //     S: '#forge:plates/steel',
+    //     I: 'minecraft:iron_ingot'
+    // });
 
     // === BALLISTIX GATING ===
     // Explosives and missiles require chemistry tier (Tier 4)
-    
-    // Remove original missile launcher recipe
-    event.remove({ output: 'ballistix:missilelauncher' });
-    
-    // Missile Launcher - requires steel plates and alloys
-    event.shaped('ballistix:missilelauncher', [
-        'SPS',
-        'PAP',
-        'SRS'
-    ], {
-        S: '#forge:plates/steel',
-        P: 'tfmg:plastic_sheet',
-        A: 'mekanism:alloy_infused',
-        R: 'minecraft:redstone_block'
-    });
-    
-    // Remove original conventional missile recipe
-    event.remove({ output: 'ballistix:missileconventional' });
-    
-    // Conventional Missile - requires plastic and steel
-    event.shaped('ballistix:missileconventional', [
-        ' I ',
-        'SES',
-        'SPS'
-    ], {
-        I: 'minecraft:iron_ingot',
-        S: '#forge:plates/steel',
-        E: 'ballistix:explosive',
-        P: 'tfmg:plastic_sheet'
-    });
+
+    // TODO: Verify item ID - Ballistix uses "Launcher Platform" not "Missile Launcher"
+    // The item ID is likely ballistix:launcherplatform
+    // event.remove({ output: 'ballistix:launcherplatform' });
+    // event.shaped('ballistix:launcherplatform', [
+    //     'SPS',
+    //     'PAP',
+    //     'SRS'
+    // ], {
+    //     S: '#forge:plates/steel',
+    //     P: 'tfmg:plastic_sheet',
+    //     A: 'mekanism:alloy_infused',
+    //     R: 'minecraft:redstone_block'
+    // });
+
+    // TODO: Verify missile item IDs
+    // event.remove({ output: 'ballistix:missileconventional' });
+    // event.shaped('ballistix:missileconventional', [
+    //     ' I ',
+    //     'SES',
+    //     'SPS'
+    // ], {
+    //     I: 'minecraft:iron_ingot',
+    //     S: '#forge:plates/steel',
+    //     E: 'ballistix:explosive',
+    //     P: 'tfmg:plastic_sheet'
+    // });
 
     // === NUCLEAR SCIENCE GATING ===
     // Nuclear technology requires chemistry and electronics tiers (Tier 4-5)
-    
-    // Remove original centrifuge recipe
-    event.remove({ output: 'nuclearscience:centrifuge' });
-    
-    // Centrifuge - requires advanced components
-    event.shaped('nuclearscience:centrifuge', [
-        'SAS',
-        'PMP',
-        'SRS'
-    ], {
-        S: '#forge:plates/steel',
-        A: 'mekanism:alloy_infused',
-        P: 'tfmg:plastic_sheet',
-        M: 'mekanism:basic_control_circuit',
-        R: 'minecraft:redstone_block'
-    });
-    
-    // Remove original reactor core recipe
-    event.remove({ output: 'nuclearscience:reactorcore' });
-    
-    // Reactor Core - requires advanced materials
-    event.shaped('nuclearscience:reactorcore', [
-        'LAL',
-        'ACA',
-        'LAL'
-    ], {
-        L: '#forge:ingots/lead',
-        A: 'mekanism:alloy_reinforced',
-        C: 'pneumaticcraft:printed_circuit_board'
-    });
+
+    // TODO: Verify item ID for centrifuge
+    // event.remove({ output: 'nuclearscience:centrifuge' });
+    // event.shaped('nuclearscience:centrifuge', [
+    //     'SAS',
+    //     'PMP',
+    //     'SRS'
+    // ], {
+    //     S: '#forge:plates/steel',
+    //     A: 'mekanism:alloy_infused',
+    //     P: 'tfmg:plastic_sheet',
+    //     M: 'mekanism:basic_control_circuit',
+    //     R: 'minecraft:redstone_block'
+    // });
+
+    // TODO: Verify item ID for reactor core
+    // event.remove({ output: 'nuclearscience:reactorcore' });
+    // event.shaped('nuclearscience:reactorcore', [
+    //     'LAL',
+    //     'ACA',
+    //     'LAL'
+    // ], {
+    //     L: '#forge:ingots/lead',
+    //     A: 'mekanism:alloy_reinforced',
+    //     C: 'pneumaticcraft:printed_circuit_board'
+    // });
 
     // === MODULAR FORCEFIELDS GATING ===
     // Forcefields require electronics tier (Tier 5)
-    
-    // Remove original projector recipe
-    event.remove({ output: 'modularforcefields:projector' });
-    
-    // Forcefield Projector - requires PCB and advanced circuits
-    event.shaped('modularforcefields:projector', [
-        'SPS',
-        'PAP',
-        'SCS'
-    ], {
-        S: '#forge:plates/steel',
-        P: 'pneumaticcraft:plastic',
-        A: 'mekanism:alloy_reinforced',
-        C: 'pneumaticcraft:printed_circuit_board'
-    });
-    
-    // Remove original coercion deriver recipe
-    event.remove({ output: 'modularforcefields:coercionderiver' });
-    
-    // Coercion Deriver - power source for forcefields
-    event.shaped('modularforcefields:coercionderiver', [
-        'SAS',
-        'ACA',
-        'SRS'
-    ], {
-        S: '#forge:plates/steel',
-        A: 'mekanism:alloy_infused',
-        C: 'pneumaticcraft:printed_circuit_board',
-        R: 'minecraft:redstone_block'
-    });
-    
-    // Remove original fortron connector recipe
-    event.remove({ output: 'modularforcefields:fortronconnector' });
-    
-    // Fortron Connector - energy transfer
-    event.shaped('modularforcefields:fortronconnector', [
-        'SWS',
-        'WAW',
-        'SWS'
-    ], {
-        S: '#forge:plates/steel',
-        W: 'immersiveengineering:wire_copper',
-        A: 'mekanism:alloy_infused'
-    });
+
+    // TODO: Verify item IDs for Modular Forcefields
+    // event.remove({ output: 'modularforcefields:projector' });
+    // event.shaped('modularforcefields:projector', [
+    //     'SPS',
+    //     'PAP',
+    //     'SCS'
+    // ], {
+    //     S: '#forge:plates/steel',
+    //     P: 'pneumaticcraft:plastic',
+    //     A: 'mekanism:alloy_reinforced',
+    //     C: 'pneumaticcraft:printed_circuit_board'
+    // });
+
+    // event.remove({ output: 'modularforcefields:coercionderiver' });
+    // event.shaped('modularforcefields:coercionderiver', [
+    //     'SAS',
+    //     'ACA',
+    //     'SRS'
+    // ], {
+    //     S: '#forge:plates/steel',
+    //     A: 'mekanism:alloy_infused',
+    //     C: 'pneumaticcraft:printed_circuit_board',
+    //     R: 'minecraft:redstone_block'
+    // });
+
+    // event.remove({ output: 'modularforcefields:fortronconnector' });
+    // event.shaped('modularforcefields:fortronconnector', [
+    //     'SWS',
+    //     'WAW',
+    //     'SWS'
+    // ], {
+    //     S: '#forge:plates/steel',
+    //     W: 'immersiveengineering:wire_copper',
+    //     A: 'mekanism:alloy_infused'
+    // });
 
     // === BALLISTIX NUCLEAR MISSILE GATING ===
     // Nuclear missiles require all advanced technologies
-    
-    // Remove original nuclear missile recipe
-    event.remove({ output: 'ballistix:missilenuclear' });
-    
-    // Nuclear Missile - endgame content requiring nuclear materials
-    event.shaped('ballistix:missilenuclear', [
-        ' U ',
-        'SPS',
-        'SCS'
-    ], {
-        U: 'nuclearscience:fuelheuo2',
-        S: '#forge:plates/steel',
-        P: 'pneumaticcraft:printed_circuit_board',
-        C: 'mineman:advanced_circuit'
-    });
+
+    // TODO: Verify nuclear missile item IDs
+    // event.remove({ output: 'ballistix:missilenuclear' });
+    // event.shaped('ballistix:missilenuclear', [
+    //     ' U ',
+    //     'SPS',
+    //     'SCS'
+    // ], {
+    //     U: 'nuclearscience:fuelheuo2',
+    //     S: '#forge:plates/steel',
+    //     P: 'pneumaticcraft:printed_circuit_board',
+    //     C: 'mineman:advanced_circuit'
+    // });
 
     // === CROSS-MOD INTEGRATION ===
     // Allow Nuclear Science uranium to be processed in Mekanism machines
-    
-    // Enriched uranium conversion
-    event.shapeless('mekanism:enriched_uranium', [
-        'nuclearscience:celluranium'
-    ]);
-    
-    event.shapeless('nuclearscience:celluranium', [
-        'mekanism:enriched_uranium'
-    ]);
 
-    console.log('Military & Defense recipe changes complete!');
+    // TODO: Verify uranium item IDs
+    // event.shapeless('mekanism:enriched_uranium', [
+    //     'nuclearscience:celluranium'
+    // ]);
+    // event.shapeless('nuclearscience:celluranium', [
+    //     'mekanism:enriched_uranium'
+    // ]);
+
+    console.log('Military & Defense recipes disabled - verify item IDs in-game');
 });

--- a/kubejs/server_scripts/recipes/tier3_plastic_multiblock.js
+++ b/kubejs/server_scripts/recipes/tier3_plastic_multiblock.js
@@ -1,33 +1,35 @@
 // kubejs/server_scripts/recipes/tier3_plastic_multiblock.js
 // IE-Only Plastic Production for IE Path Players
 // Uses Immersive Engineering mechanics exclusively - no Create required
+//
+// Requires: KubeJS Immersive Engineering UNOFFICIAL for 1.20.1
+// https://www.curseforge.com/minecraft/mc-mods/kubejs-immersive-engineering-unofficial
 
 ServerEvents.recipes(event => {
     console.log('Adding IE-based plastic production recipes...');
 
-    // === INTERMEDIATE ITEM: UNPROCESSED PLASTIC ===
-    // Create an unprocessed plastic item that IE players can make
-    // This will be pressed into plastic sheets using IE Metal Press
-    
-    // Define unprocessed plastic if not already defined by another mod
-    // Using IE's treated wood bucket as a template for custom item pattern
+    // Define unprocessed plastic item
     const UNPROCESSED_PLASTIC = 'kubejs:unprocessed_plastic';
-    
+
     // === STEP 1: REFINE OIL TO ETHYLENE ===
     // Use IE Refinery multiblock to process oil into ethylene (using TFMG fluid)
     // Immersive Petroleum oil → ethylene (fluid intermediate for plastic)
-    event.recipes.immersiveengineering.refinery(
-        Fluid.of('tfmg:ethylene', 100),            // Output: 100mb ethylene (TFMG fluid)
-        Fluid.of('immersivepetroleum:oil', 250),   // Input: 250mb crude oil
-        Fluid.of('minecraft:empty', 0),            // No second fluid input
-        512                                        // Energy: 512 RF
-    );
+    // NOTE: Refinery recipe may be broken in some KubeJS IE versions
+    // If this doesn't work, use Immersive Petroleum's native distillation instead
+    try {
+        event.recipes.immersiveengineering.refinery(
+            Fluid.of('tfmg:ethylene', 100),                // Output: 100mb ethylene (TFMG fluid)
+            [Fluid.of('immersivepetroleum:oil', 250)]      // Input: 250mb crude oil (array format)
+        ).energy(512);
+    } catch (e) {
+        console.log('IE Refinery recipe failed - use Immersive Petroleum distillation instead');
+    }
 
     // === STEP 2: CHEMICAL MIXER MULTIBLOCK - ETHYLENE TO UNPROCESSED PLASTIC ===
     // Use MBD2 Chemical Plant multiblock built with IE blocks
     // This creates a semi-solid unprocessed plastic item
     // Multiblock: mbd2:chemical_plant - build using MBD2 preview in-game
-    // Recipe defined in mbd2_machines.js
+    // Recipe defined in MBD2's internal recipe system
 
     // === STEP 3: METAL PRESS - STAMP INTO PLASTIC SHEETS ===
     // Use IE Metal Press to stamp unprocessed plastic into plastic sheets
@@ -35,23 +37,26 @@ ServerEvents.recipes(event => {
     event.recipes.immersiveengineering.metal_press(
         '2x tfmg:plastic_sheet',                   // Output: 2 plastic sheets
         UNPROCESSED_PLASTIC,                       // Input: unprocessed plastic
-        'immersiveengineering:mold_plate',         // Mold: plate mold
-        2400,                                      // Energy: 2400 RF
-        1                                          // Input size: 1
-    );
+        'immersiveengineering:mold_plate'          // Mold: plate mold
+    ).energy(2400);
 
     // === ALTERNATIVE: DIRECT REFINERY RECIPE (Less Efficient) ===
     // For early game before having full IE automation
     // Higher oil cost but simpler single-machine process
     // Uses TFMG molten_plastic as intermediate (can be cast directly)
-    event.recipes.immersiveengineering.refinery(
-        Fluid.of('tfmg:molten_plastic', 125),      // Output: molten plastic (TFMG fluid, can be cast)
-        Fluid.of('immersivepetroleum:oil', 500),   // Input: 500mb crude oil (2x cost)
-        Fluid.of('minecraft:lava', 100),           // Input: 100mb lava (heat source)
-        1024                                       // Energy: 1024 RF (2x cost)
-    );
+    try {
+        event.recipes.immersiveengineering.refinery(
+            Fluid.of('tfmg:molten_plastic', 125),          // Output: molten plastic (TFMG fluid)
+            [
+                Fluid.of('immersivepetroleum:oil', 500),   // Input: 500mb crude oil (2x cost)
+                Fluid.of('minecraft:lava', 100)            // Input: 100mb lava (heat source)
+            ]
+        ).energy(1024);
+    } catch (e) {
+        console.log('IE Refinery alt recipe failed');
+    }
 
-    // Cast molten plastic directly into sheets (emergency recipe)
+    // Cast molten plastic directly into sheets using bottling machine
     event.recipes.immersiveengineering.bottling(
         'tfmg:plastic_sheet',                      // Output: 1 plastic sheet
         'minecraft:bucket',                        // Input: bucket (returns empty)
@@ -74,7 +79,7 @@ ServerEvents.recipes(event => {
 // Use the MBD2 in-game preview system to build the Chemical Plant structure.
 // Right-click with empty hand on the controller to see the required structure.
 //
-// Recipe (defined in mbd2_machines.js):
+// Recipe (defined in MBD2's internal recipe system):
 // - Input: 100mb Ethylene (from IE Refinery, using TFMG fluid)
 // - Input: 1x Coal Coke (catalyst)
 // - Output: 1x Unprocessed Plastic (solid item)

--- a/mods/kubejs-immersive-engineering-unofficial.pw.toml
+++ b/mods/kubejs-immersive-engineering-unofficial.pw.toml
@@ -1,0 +1,13 @@
+name = "KubeJS Immersive Engineering UNOFFICIAL"
+filename = "kubejs-immersive-engineering-2001.5.29-build.23.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "aa319636e1de4ce92a982a9fda1a954ed71f03a7"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 6593605
+project-id = 1141738

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "b8c5f4b1997a874d3da03792fa05ccc33b8a2f3b771a80499d5a137b86336c67"
+hash = "77eb0b59bcff1d42897a83785a65c9ddb5d5e0dc3022850225b3098306d48c7e"
 
 [versions]
 forge = "47.4.13"


### PR DESCRIPTION
## Summary
- Add KubeJS Immersive Engineering UNOFFICIAL for 1.20.1 IE recipe support
- Fix mbd2_machines.js: Document that MBD2 uses internal recipe system, not KubeJS
- Fix military_defense.js: Comment out recipes pending item ID verification
- Fix tier3_plastic_multiblock.js: Correct IE recipe syntax (array format, .energy() method)

## Details
The recipe errors were caused by:
1. **MBD2 recipes**: The `mbd2:mbd_recipe` type doesn't exist - MBD2 machines use their internal recipe system defined in .mb files
2. **Military/Defense mods**: Item IDs need verification in-game (Ballistix, Blastcraft, Nuclear Science, Modular Forcefields use specific naming conventions)
3. **IE recipes**: Syntax was incorrect and the KubeJS IE addon was missing

## Test plan
- [ ] Verify game launches without recipe errors
- [ ] Verify IE Metal Press and Bottling recipes work
- [ ] Verify MBD2 multiblocks function with internal recipes
- [ ] Verify military mod item IDs in JEI and update recipes accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)